### PR TITLE
App crashed & closed without calendar permissions

### DIFF
--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -413,9 +413,10 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 // If request is cancelled, the result arrays are empty.
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-
                     // permission was granted, yay!
-
+                    if (mController.getViewType() == ViewType.MONTH) {
+                        initFragments(mController.getTime(), ViewType.MONTH, null);
+                    }
                 } else {
                     Toast.makeText(getApplicationContext(), R.string.user_rejected_calendar_write_permission, Toast.LENGTH_LONG).show();
                 }
@@ -1083,10 +1084,10 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
             default:
                 mNavigationView.getMenu().findItem(R.id.week_menu_item).setChecked(true);
                 frag = new DayFragment();
-                Bundle bundle = new Bundle();
-                bundle.putLong("timeInMillis", timeMillis);
-                bundle.putInt("numOfDays", Utils.getDaysPerWeek(this));
-                frag.setArguments(bundle);
+                Bundle dayViewBundle = new Bundle();
+                dayViewBundle.putLong("timeInMillis", timeMillis);
+                dayViewBundle.putInt("numOfDays", Utils.getDaysPerWeek(this));
+                frag.setArguments(dayViewBundle);
                 if (mIsTabletConfig) {
                     mToolbar.setTitle(R.string.week_view);
                 }

--- a/src/com/android/calendar/agenda/AgendaWindowAdapter.java
+++ b/src/com/android/calendar/agenda/AgendaWindowAdapter.java
@@ -16,19 +16,23 @@
 
 package com.android.calendar.agenda;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.AsyncQueryHandler;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.provider.CalendarContract;
 import android.provider.CalendarContract.Attendees;
 import android.provider.CalendarContract.Calendars;
 import android.provider.CalendarContract.Instances;
+import android.support.v4.content.ContextCompat;
 import android.text.format.DateUtils;
 import android.text.format.Time;
 import android.util.Log;
@@ -1085,7 +1089,11 @@ public class AgendaWindowAdapter extends BaseAdapter
 
             if (cursor == null) {
                 if (mAgendaListView != null && mAgendaListView.getContext() instanceof Activity) {
-                    ((Activity) mAgendaListView.getContext()).finish();
+                    if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(mContext,
+                            Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
+                        //If permission is not granted then return.
+                        mHeaderView.setText(R.string.calendar_permission_not_granted);
+                    }
                 }
                 return;
             }

--- a/src/com/android/calendar/month/MonthByWeekFragment.java
+++ b/src/com/android/calendar/month/MonthByWeekFragment.java
@@ -16,22 +16,26 @@
 
 package com.android.calendar.month;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.FragmentManager;
 import android.app.LoaderManager;
 import android.content.ContentUris;
 import android.content.CursorLoader;
 import android.content.Loader;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.drawable.StateListDrawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.provider.CalendarContract.Attendees;
 import android.provider.CalendarContract.Calendars;
 import android.provider.CalendarContract.Instances;
+import android.support.v4.content.ContextCompat;
 import android.text.format.DateUtils;
 import android.text.format.Time;
 import android.util.Log;
@@ -337,7 +341,11 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
                             - (mNumWeeks * 7 / 2);
             mEventUri = updateUri();
             String where = updateWhere();
-
+            if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(mContext,
+                    Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
+                //If permission is not granted then return.
+                return null;
+            }
             loader = new CursorLoader(
                     getActivity(), mEventUri, Event.EVENT_PROJECTION, where,
                     null /* WHERE_CALENDARS_SELECTED_ARGS */, INSTANCES_SORT_ORDER);


### PR DESCRIPTION
- Fixed Month View crashes when calendar permission not granted
- Fixed Agenda view closing app issue, when calendar permission not granted. Without 
   the required permission, the Agenda view was closing the app
- Added functionality to refresh the Month view, once calendar permission granted